### PR TITLE
docs(readme): improve `PATH` export examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -162,11 +162,11 @@ Basic salt binary setup with version 3004:
    $ saltenv init
    Add the saltenv bin directory to your PATH:
 
-       echo 'export PATH="$PATH:/home/nmhughes/.saltenv/bin"' >> ~/.bashrc
+       echo 'export PATH="$HOME/.saltenv/bin:$PATH"' >> ~/.bashrc
    OR:
-       echo 'export PATH="$PATH:/home/nmhughes/.saltenv/bin"' >> ~/.zshrc
+       echo 'export PATH="$HOME/.saltenv/bin:$PATH"' >> ~/.zshrc
 
-   $ echo 'export PATH="$PATH:/home/nmhughes/.saltenv/bin"' >> ~/.zshrc
+   $ echo 'export PATH="$HOME/.saltenv/bin:$PATH"' >> ~/.zshrc
    $ source ~/.zshrc
 
 


### PR DESCRIPTION
Improvements:

* Use `$HOME`
* Add `saltenv` path before `$PATH`

Ensure consistency with related projects:

* https://github.com/rbenv/rbenv#basic-github-checkout
* https://github.com/pyenv/pyenv#basic-github-checkout
* https://github.com/tfutils/tfenv#manual
* https://github.com/little-angry-clouds/kubernetes-binaries-managers/tree/master/cmd/kbenv#manually
* https://github.com/yuya-takeyama/helmenv#installation